### PR TITLE
Fix broken links for Tim Sutton

### DIFF
--- a/foss4guk2022local/boveytracey.md
+++ b/foss4guk2022local/boveytracey.md
@@ -32,14 +32,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.

--- a/foss4guk2022local/bristol.md
+++ b/foss4guk2022local/bristol.md
@@ -34,14 +34,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.

--- a/foss4guk2022local/cardiff.md
+++ b/foss4guk2022local/cardiff.md
@@ -33,14 +33,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.

--- a/foss4guk2022local/glasgow.md
+++ b/foss4guk2022local/glasgow.md
@@ -27,14 +27,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.

--- a/foss4guk2022local/index.md
+++ b/foss4guk2022local/index.md
@@ -8,9 +8,9 @@ layout: foss4guk2022
 
 [OSGeo:UK](https://uk.osgeo.org/) will be bringing together all those interested in free and open source software for geospatial (FOSS4G) for this fantastic event. If you use, promote, develop or want to learn about open source tools and open data for geospatial, then this conference is for you! A whole day of talks, workshops and networking across the UK. Take a look at our previous programmes for [FOSS4GUK Online 2020](https://uk.osgeo.org/foss4gukonline2020/programme.html) and [FOSS4GUK 2019 in Edinburgh](https://uk.osgeo.org/foss4guk2019/FOSS4GUK_2019_Programme.pdf) to get a flavour of things to come!
 
-We are running FOSS4G:UK Local 2022 on Thu 17th Nov 2022, on [PostGIS](https://postgisday.rocks/) day. This will be a hybrid conference, but with a twist: there will be no central physical location. We have 8 venues geographically dispersed across the UK, where you can physically meet up to attend the conference. The three keynote presentations and some additional sessions will be streamed to all venues. Additional sessions will be run at each local venue. 
+We are running FOSS4G:UK Local 2022 on Thu 17th Nov 2022, on [PostGIS](https://postgisday.rocks/) day. This will be a hybrid conference, but with a twist: there will be no central physical location. We have 8 venues geographically dispersed across the UK, where you can physically meet up to attend the conference. The three keynote presentations and some additional sessions will be streamed to all venues. Additional sessions will be run at each local venue.
 
-If there is no physical location near you, you could host your own. Venues don’t need to be big - you can meet up with a couple of friends locally if that works for you. If you would like to host an extra venue please let us know. You will also be able to join remotely and view the streamed sessions from wherever you are, if you can’t get to a venue. We will also have the [OSGeo:UK Matrix room](https://matrix.to/#/#OSGeoUK:matrix.org) to allow people to chat to each other before, during and after the event. 
+If there is no physical location near you, you could host your own. Venues don’t need to be big - you can meet up with a couple of friends locally if that works for you. If you would like to host an extra venue please let us know. You will also be able to join remotely and view the streamed sessions from wherever you are, if you can’t get to a venue. We will also have the [OSGeo:UK Matrix room](https://matrix.to/#/#OSGeoUK:matrix.org) to allow people to chat to each other before, during and after the event.
 
 ## Venues
 
@@ -38,22 +38,22 @@ We want to hear from you! We are open to any talks about FOSS4G (free and open s
 - Interesting applications of FOSS4G across industry, commercial, public sector or third sector
 - How to use FOSS4G and related software at a range of levels
 
-We also have a number of different formats and lengths, or you can proposed your own: 
+We also have a number of different formats and lengths, or you can proposed your own:
 
 - Lightning talks (5-10 min)
 - Presentations (30 min)
 - Workshops (1hr or 2hr)
 - Show and tell (short & variable)
-	
 
-The call for talks is [now open](https://forms.gle/HfBkq5LSrDpCfp4G9), and will close on Fri 14th Oct 2022. Please note you will be required which venue you would like to travel to to present your talk. Any general queries please contact the national chair, Nick Bearman or <span class="osgeoemail"></span>. Any venue specific query please contact the local venue chair, listed above. 
+
+The call for talks is [now open](https://forms.gle/HfBkq5LSrDpCfp4G9), and will close on Fri 14th Oct 2022. Please note you will be required which venue you would like to travel to to present your talk. Any general queries please contact the national chair, Nick Bearman or <span class="osgeoemail"></span>. Any venue specific query please contact the local venue chair, listed above.
 
 ## Schedule
 
 The national schedule for Thurs 17th Nov 2022 is:
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - local arrangements
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
@@ -67,7 +67,7 @@ We are delighted to have keynote presentations from three leading contibutors to
 
 ## Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) Follow us on [Twitter](https://twitter.com/osgeouk) / [#FOSS4GUK](https://twitter.com/search?q=%23FOSS4GUK&src=typed_query), join our [mailing list](https://lists.osgeo.org/mailman/listinfo/uk), and keep an eye on this site for more details. 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) Follow us on [Twitter](https://twitter.com/osgeouk) / [#FOSS4GUK](https://twitter.com/search?q=%23FOSS4GUK&src=typed_query), join our [mailing list](https://lists.osgeo.org/mailman/listinfo/uk), and keep an eye on this site for more details.
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) to one of these causes:
 

--- a/foss4guk2022local/keyworth.md
+++ b/foss4guk2022local/keyworth.md
@@ -41,7 +41,7 @@ Car:
 
 The preferred postcode for satellite navigation is NG12 5GD.  See [Google maps directions](https://www.google.com/maps/dir//NG12+5GD,+Nicker+Hill,+Keyworth,+Nottingham/@52.879317,-1.0820298,17z/data=!4m8!4m7!1m0!1m5!1m1!1s0x4879c4b073bb09fb:0x31e767532086c11d!2m2!1d-1.081564!2d52.8795395). There is visitor parking on site.  You will need to record your car registration number on arrival.
 
-### Registration 
+### Registration
 
 Please register via [the FOSS4GUK form](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) (Deadline 10 November 2022).  Due to limitations on the room size, the number of delegates is limited to 25 on a first-come, first-served basis.  If there is demand we will look to increase this closer to the time.  Coffee and lunch will be provided; please indicate any dietary requirements on the form.
 
@@ -54,7 +54,7 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *Local sessions: Lightning talks and workshops*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up

--- a/foss4guk2022local/leeds.md
+++ b/foss4guk2022local/leeds.md
@@ -34,14 +34,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.

--- a/foss4guk2022local/london.md
+++ b/foss4guk2022local/london.md
@@ -29,14 +29,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.

--- a/foss4guk2022local/manchester.md
+++ b/foss4guk2022local/manchester.md
@@ -29,14 +29,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.

--- a/foss4guk2022local/southampton.md
+++ b/foss4guk2022local/southampton.md
@@ -29,9 +29,9 @@ Getting there: [https://www.ordnancesurvey.co.uk/contact-us/find-us-page](https:
 
 We encourage everyone to travel by public transport/car share/ under their own steam if possible.
 
-Train: Best station is Southampton Central, then by taxi (about 15 min) or [local bus number 17](https://www.bluestarbus.co.uk/services/BLUS/17). 
+Train: Best station is Southampton Central, then by taxi (about 15 min) or [local bus number 17](https://www.bluestarbus.co.uk/services/BLUS/17).
 
-Car: A visitors car park is available. 
+Car: A visitors car park is available.
 
 ### Programme
 
@@ -39,15 +39,15 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.
 
@@ -57,7 +57,7 @@ Participants at FOSS4G:UK Local 2022 are expected to act respectfully toward oth
 
 ### Questions
 
-Any questions, please contact the local venue chairs (details above) or email [osgeouk@gmail.com](mailto:osgeouk@gmail.com). 
+Any questions, please contact the local venue chairs (details above) or email [osgeouk@gmail.com](mailto:osgeouk@gmail.com).
 
 
 

--- a/foss4guk2022local/worcester.md
+++ b/foss4guk2022local/worcester.md
@@ -32,14 +32,14 @@ The schedule for Thurs 17th Nov 2022 is:
 - 09:00 - 09:30 - Arrivals and coffee
 - 09:30 - 10:00 - Opening and welcome
 - 10:00 - 10:30 - [Anita Graser](https://anitagraser.com/) (online): Shaping Open Spatial Data Science
-- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/en/people/person/tim/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
+- 10:30 - 11:00 - [Tim Sutton](https://kartoza.com/the_team/HR-EMP-00002/) (online): 20 Years of QGIS: Successes and Failures of a Global Phenomenon
 - 11:00 - 16:00 - *local arrangements will be confirmed nearer the time*
 - 16:00 - 16:30 - [Regina Obe](https://twitter.com/reginaobe) (online): PostGIS Vision: Past, Present, and Future
 - 16:30 - 16:45 - Wrap-up
 - 16:45 onwards - local arrangements
 
-### Registration 
+### Registration
 
-[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087) 
+[Registration is now open!](https://www.eventbrite.co.uk/e/foss4g-uk-local-2022-tickets-405826868087)
 
 The event is free to attend but we *strongly* encourage attendees (and/or their employers) to make a donation of £20 (more if you can afford or less if you can't) - see [here](https://uk.osgeo.org/foss4guk2022local/index.html#registration) for details.


### PR DESCRIPTION
The link to Tim Sutton's staff profile at Kartoza, located in the FOSS4GUK 2022 schedules, is broken.

Replace with the link of what appears to be the intended page.

(It also seems my default linting settings have trimmed off a few dozen trailing spaces...)