### PR TITLE
Disambiguate Lancaster travel details

### DIFF
--- a/foss4guklocal2023/lancaster.md
+++ b/foss4guklocal2023/lancaster.md
@@ -19,9 +19,9 @@ lunch and refreshments.<br>
 
 * Venue: [Fraser House Hub](https://www.openstreetmap.org/#map=19/54.04438/-2.79759)
 
-* From Lancaster rail station: [about 15m on foot](https://www.openstreetmap.org/directions?engine=fossgis_valhalla_foot&route=54.0481%2C-2.8073%3B54.0444%2C-2.7976#map=16/54.0464/-2.8025)
+* From Lancaster rail station: [about 15 minutes on foot](https://www.openstreetmap.org/directions?engine=fossgis_valhalla_foot&route=54.0481%2C-2.8073%3B54.0444%2C-2.7976#map=16/54.0464/-2.8025)
 
-* From Lancaster bus station: [about 15m on foot](https://www.openstreetmap.org/directions?engine=fossgis_valhalla_foot&route=54.0505%2C-2.8007%3B54.0444%2C-2.7976#map=18/54.05002/-2.80047) or get off at White Cross or the Infirmary and you'll be right in front of 
+* From Lancaster bus station: [about 15 minutes on foot](https://www.openstreetmap.org/directions?engine=fossgis_valhalla_foot&route=54.0505%2C-2.8007%3B54.0444%2C-2.7976#map=18/54.05002/-2.80047) or get off at White Cross or the Infirmary and you'll be right in front of 
 the site.
 
 * By car: there may be limited guest parking available.


### PR DESCRIPTION
The abbreviation "15m" for travel is ambiguous between 15 metres (very easy!) and 15 minutes. The difference may matter to those less able to walk.