### PR TITLE
Fix Idox logo URL and add to local sponsor page

### DIFF
--- a/foss4guklocal2023/keyworth.md
+++ b/foss4guklocal2023/keyworth.md
@@ -57,6 +57,18 @@ Time | Speaker| Title|
 -|Conference end|-
 16:45 - ?|Evening social event in Nottingham|TBC
 
+
+### Sponsors
+
+FOSS4G UK are very grateful to the [British Geological Survey](https://www.bgs.ac.uk/) for sponsoring and hosting FOSS4G:UK Local at this event.
+
+[<img src="https://www.bgs.ac.uk/wp-content/uploads/2022/08/BGS-Logo-Pos-RGB.svg" width="300" align="middle">](https://www.bgs.ac.uk/)
+
+FOSS4G UK are also very grateful to [Idox](https://www.idoxgroup.com/) for their local sponsorship support.
+
+[<img src="images/Idox_Logo_CMYK.jpg" width="200" align="middle">](https://www.idoxgroup.com/)
+
+
 ### Location & Travel
 
 The event will be held in the BGS Conference Suite, accessed via the main reception. The British Geological Survey (BGS) headquarters are located in Keyworth, southeast of Nottingham, in the Midlands of England.
@@ -87,15 +99,6 @@ There is bike parking next to reception.
 Car:
 
 The preferred postcode for satellite navigation is NG12 5GD.  See [Google maps directions](https://www.google.com/maps/dir//NG12+5GD,+Nicker+Hill,+Keyworth,+Nottingham/@52.879317,-1.0820298,17z/data=!4m8!4m7!1m0!1m5!1m1!1s0x4879c4b073bb09fb:0x31e767532086c11d!2m2!1d-1.081564!2d52.8795395). There is visitor parking on site.  You will need to record your car registration number on arrival.
-
-### Sponsors
-FOSS4G UK are very grateful to [Idox](https://www.idoxgroup.com/) for supporting FOSS4G:UK Local at this event.
-
-![Idox Logo](foss4guklocal2023/images/Idox_Logo_CMYK.jpg)
-
-FOSS4G UK are very grateful to the [British Geological Survey](https://www.bgs.ac.uk/) for supporting FOSS4G:UK Local at this event.
-
-[<img src="https://www.bgs.ac.uk/wp-content/uploads/2022/08/BGS-Logo-Pos-RGB.svg" width="300" align="middle">](https://www.bgs.ac.uk/)
 
 
 ### Questions

--- a/foss4guklocal2023/keyworth.md
+++ b/foss4guklocal2023/keyworth.md
@@ -11,7 +11,7 @@ Local Venue Chairs: [John Stevenson](mailto:jostev@bgs.ac.uk), [Rachel Talbot](m
 
 ### Registration
 
-[Registration](https://www.eventbrite.co.uk/e/foss4g-uk-local-2023-tickets-663598610307){:target="_newpage"} is still open, only 7 spaces remaining! Join our [our mailing list](https://lists.osgeo.org/mailman/listinfo/uk){:target="_newpage"} to keep up to date with news. 
+[Registration](https://www.eventbrite.co.uk/e/foss4g-uk-local-2023-tickets-663598610307){:target="_newpage"} is still open, only 5 spaces remaining! Join our [our mailing list](https://lists.osgeo.org/mailman/listinfo/uk){:target="_newpage"} to keep up to date with news. 
 
 ### Programme - Thursday 7th September 2023
 

--- a/foss4guklocal2023/sponsorship.md
+++ b/foss4guklocal2023/sponsorship.md
@@ -14,7 +14,9 @@ Many thanks to all of our sponsors. Please do check out their websites:
 
 [<img src="images/geoxphere.png" width="200" align="middle">](https://www.geoxphere.com/)
 
-[<img src="./images/osgeo-ie.png" width="200" align="middle">](https://wiki.osgeo.org/wiki/Ireland)
+[<img src="images/Idox_Logo_CMYK.jpg" width="200" align="middle">](https://www.idoxgroup.com/)
+
+[<img src="images/osgeo-ie.png" width="200" align="middle">](https://wiki.osgeo.org/wiki/Ireland)
 
 [<img src="images/sparkgeo-logo-black.png" width="200" align="middle">](https://sparkgeo.com/)
 


### PR DESCRIPTION
This merge request fixes the Idox logo on the Keyworth page and adds it to the Local Sponsor pages.

It turned out that the link was broken because it was relative to the project root, whereas the whole website is served from within the `foss4guklocal2023` folder.

cc @rachelesmee 