### PR TITLE
Remove training courses on Spatial Data and R

### DIFF
--- a/_data/osgeouk_training.csv
+++ b/_data/osgeouk_training.csv
@@ -1,4 +1,2 @@
 description,date,organisation,location,link
 Introduction to QGIS: Understanding and Presenting Spatial Data, 26 May 1 June 2026, Nick Bearman, Online, https://nickbearman.com/training-courses.html#introduction-to-qgis-understanding-and-presenting-spatial-data
-Introduction to Spatial Data and R as a GIS, 28-29 Apr 2026, Nick Bearman & NCRM, Online, https://nickbearman.github.io/training-courses.html#introduction-to-spatial-data-using-r-as-a-gis
-Advanced R as a GIS: Spatial Analysis and Statistics, 19-20 May 2026, Nick Bearman & NCRM, Online, https://nickbearman.github.io/training-courses.html#advanced-R-as-a-gis-spatial-analysis-and-statistics


### PR DESCRIPTION
Removed two training course entries related to R as a GIS.

Sorry Json, I should have removed the old courses too..