### PR TITLE
docs: fix Lightening talaks -> Lightning talks

### DIFF
--- a/foss4guk2026/callfortalks/index.md
+++ b/foss4guk2026/callfortalks/index.md
@@ -15,7 +15,7 @@ Presentations and Workshops are the beating heart of the FOSS4G conference. They
 
 Presentations are limited to 20 minutes of content with 5 minutes for questions. Presentations are delivered in the General Sessions over the conference days.
 
-Lightening talaks are limited to 5 minutes of content with no questions. Presentations are delivered in a special session.
+Lightning talks are limited to 5 minutes of content with no questions. Presentations are delivered in a special session.
 
 ### Workshops
 


### PR DESCRIPTION
## Summary

Closes #249. `foss4guk2026/callfortalks/index.md:18` advertised the short-talk format as "Lightening talaks" - two typos in three words. The line should read "Lightning talks", matching the surrounding sentences that spell `talks` correctly and the entry's parallel-construction sibling about presentations.

## Why this matters

This is the public Call for Talks page for FOSS4G:UK 2026. Anyone landing on the page to consider submitting sees the typo immediately above the format description, which dulls the page's polish. Two-word fix.

## How to test

```
$ grep -n "Lightening\|talaks" foss4guk2026/callfortalks/index.md
(empty)
$ grep -n "Lightning talks" foss4guk2026/callfortalks/index.md
18:Lightning talks are limited to 5 minutes of content with no questions. Presentations are delivered in a special session.
```

Fixes #249

AI-assisted.
