### PR TITLE
Fix grammatical error in AMA session details

### DIFF
--- a/foss4guk2026/ama/index.md
+++ b/foss4guk2026/ama/index.md
@@ -9,7 +9,7 @@ title: Ask Me Anything Session
 
 <p>
   The AMA (Ask Me Anything) session was scheduled for <strong>12 June 2026 at 12:00 PM, London time</strong>.
-  We discussed event, the programme, volunteering, sponsorship, or practical attendance details.
+  We discussed event, the programme, volunteering, sponsorship, and practical attendance details.
 </p>
 
 <p>


### PR DESCRIPTION
Change sponsorship, or practical attendance details. to sponsorship, and practical attendance details.