### PR TITLE
Add submission deadline to FOSS4G:UK 2026 Call for Talks page

### DIFF
--- a/foss4guk2026/callfortalks/index.md
+++ b/foss4guk2026/callfortalks/index.md
@@ -5,6 +5,8 @@ title: FOSS4G:UK 2026 Leeds Call for Talks
 <img src="../assets/images/logo.svg" alt="FOSS4G:UK 2026 Leeds logo" style="max-height:200px; margin: auto; display: block;">
 The Call for Talks is __OPEN__!
 
+The deadline for submissions is **midday on 31 July 2026**.
+
 <div style="text-align: center; margin: 30px 0;">
   <a href="https://talks.osgeo.org/foss4g-uk-2026/cfp" class="btn btn-primary btn-lg">Submit Your Talk</a>
 </div>


### PR DESCRIPTION
## Summary

Surfaces the Call for Talks deadline on the FOSS4G:UK 2026 Call for Talks page (uk.osgeo.org/foss4guk2026/callfortalks/).

## Change

Added the following line immediately below the `__OPEN__!` notice in `foss4guk2026/callfortalks/index.md`:

> The deadline for submissions is **midday on 31 July 2026**.

This places the deadline prominently near the 'Submit Your Talk' button so visitors see it before clicking through to pretalx.

## Context

The deadline (midday, 31 July 2026) matches the early bird ticket cutoff and is the CFP close date on the OSGeo pretalx platform. Flagging it directly on the page saves visitors from having to dig for it.